### PR TITLE
Feature: API Gateway Kubernetes 적용 및 Profile 환경 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 
+	// 쿠버네티스 라이브러리
+	implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-all'
+	implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok:1.18.22'
 

--- a/src/main/resources/application-kubernetes.yaml
+++ b/src/main/resources/application-kubernetes.yaml
@@ -22,19 +22,13 @@ spring:
     name: gateway-service
   config:
     activate:
-      on-profile: default
+      on-profile: kubernetes
   cloud:
     gateway:
       discovery:
         locator:
           enabled: true
-          lowerCaseServiceId: true
-      default-filters:
-        - name: GlobalFilter
-          args:
-            baseMessage: Spring Cloud Gateway Global Filter
-            preLogger: true
-            postLogger: true
+          lower-case-service-id: true
       routes:
         - id: auth-service
           uri: lb://AUTH-SERVICE
@@ -114,13 +108,8 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/post-service/(?<segment>.*), /$\{segment}
-
-
 eureka:
-  instance:
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
   client:
-    fetch-registry: true
-    register-with-eureka: true
-    service-url:
-      defaultZone: http://127.0.0.1:8761/eureka
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false

--- a/src/main/resources/bootstrap-kubernetes.yaml
+++ b/src/main/resources/bootstrap-kubernetes.yaml
@@ -1,0 +1,15 @@
+spring:
+  config:
+    activate:
+      on-profile: kubernetes
+  cloud:
+    config:
+      enabled: false
+    kubernetes:
+      enabled: true
+      config:
+        enabled: true
+        name: gateway-config
+        namespace: default
+      loadbalancer:
+        mode: service

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,7 +1,12 @@
 spring:
+  config:
+    activate:
+      on-profile: default
   cloud:
     config:
       uri: http://127.0.0.1:8888
       name: auth-service
-#  profiles:
-#    active: dev
+    kubernetes:
+      enabled: false
+      config:
+        enabled: false


### PR DESCRIPTION
API Gateway를 쿠버네티스 상에서 사용할 수 있도록 Spring Cloud Kubernetes 라이브러리를 추가하였다.

이로써 현재 API Gateway에는 Local에서 사용하는 Spring Cloud 라이브러리와
K8S 환경에서 사용하는 Spring Cloud Kubernetes 라이브러리가 함께 있기 때문에
환경에 맞는 프로퍼티를 사용하기 위해서 Profile 을 사용해서 환경 분리를 시켜주었다.